### PR TITLE
fix: always altruist when missing chain check

### DIFF
--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -520,6 +520,26 @@ export class PocketRelayer {
           chainCheckedNodes = (chainCheckResult as PromiseFulfilledResult<Node[]>).value
         }
       } else {
+        const error = 'ChainID check failure'
+        const method = 'checks'
+
+        await this.metricsRecorder.recordMetric({
+          requestID,
+          applicationID: application.id,
+          applicationPublicKey: application.gatewayAAT.applicationPublicKey,
+          blockchainID,
+          serviceNode: 'session-failure',
+          relayStart,
+          result: 500,
+          bytes: Buffer.byteLength(error, 'utf8'),
+          delivered: false,
+          fallback: false,
+          method,
+          error,
+          origin: this.origin,
+          data,
+          sessionKey,
+        })
         return new Error('ChainID check failure; using fallbacks')
       }
 

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -515,14 +515,18 @@ export class PocketRelayer {
 
       const [chainCheckResult, syncCheckResult] = await checkersPromise
 
-      if (blockchainIDCheck && this.isCheckPromiseResolved(chainCheckResult)) {
-        chainCheckedNodes = (chainCheckResult as PromiseFulfilledResult<Node[]>).value
+      if (blockchainIDCheck) {
+        if (this.isCheckPromiseResolved(chainCheckResult)) {
+          chainCheckedNodes = (chainCheckResult as PromiseFulfilledResult<Node[]>).value
+        }
       } else {
         return new Error('ChainID check failure; using fallbacks')
       }
 
-      if (blockchainSyncCheck && this.isCheckPromiseResolved(syncCheckResult)) {
-        syncCheckedNodes = (syncCheckResult as PromiseFulfilledResult<Node[]>).value
+      if (blockchainSyncCheck) {
+        if (this.isCheckPromiseResolved(syncCheckResult)) {
+          syncCheckedNodes = (syncCheckResult as PromiseFulfilledResult<Node[]>).value
+        }
       } else {
         const error = 'Sync check failure'
         const method = 'checks'

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -518,59 +518,59 @@ export class PocketRelayer {
       if (blockchainIDCheck) {
         if (this.isCheckPromiseResolved(chainCheckResult)) {
           chainCheckedNodes = (chainCheckResult as PromiseFulfilledResult<Node[]>).value
+        } else {
+          const error = 'ChainID check failure'
+          const method = 'checks'
+
+          await this.metricsRecorder.recordMetric({
+            requestID,
+            applicationID: application.id,
+            applicationPublicKey: application.gatewayAAT.applicationPublicKey,
+            blockchainID,
+            serviceNode: 'session-failure',
+            relayStart,
+            result: 500,
+            bytes: Buffer.byteLength(error, 'utf8'),
+            delivered: false,
+            fallback: false,
+            method,
+            error,
+            origin: this.origin,
+            data,
+            sessionKey,
+          })
+
+          return new Error('ChainID check failure; using fallbacks')
         }
-      } else {
-        const error = 'ChainID check failure'
-        const method = 'checks'
-
-        await this.metricsRecorder.recordMetric({
-          requestID,
-          applicationID: application.id,
-          applicationPublicKey: application.gatewayAAT.applicationPublicKey,
-          blockchainID,
-          serviceNode: 'session-failure',
-          relayStart,
-          result: 500,
-          bytes: Buffer.byteLength(error, 'utf8'),
-          delivered: false,
-          fallback: false,
-          method,
-          error,
-          origin: this.origin,
-          data,
-          sessionKey,
-        })
-
-        return new Error('ChainID check failure; using fallbacks')
       }
 
       if (blockchainSyncCheck) {
         if (this.isCheckPromiseResolved(syncCheckResult)) {
           syncCheckedNodes = (syncCheckResult as PromiseFulfilledResult<Node[]>).value
+        } else {
+          const error = 'Sync check failure'
+          const method = 'checks'
+
+          await this.metricsRecorder.recordMetric({
+            requestID,
+            applicationID: application.id,
+            applicationPublicKey: application.gatewayAAT.applicationPublicKey,
+            blockchainID,
+            serviceNode: 'session-failure',
+            relayStart,
+            result: 500,
+            bytes: Buffer.byteLength(error, 'utf8'),
+            delivered: false,
+            fallback: false,
+            method,
+            error,
+            origin: this.origin,
+            data,
+            sessionKey,
+          })
+
+          return new Error('Sync check failure; using fallbacks')
         }
-      } else {
-        const error = 'Sync check failure'
-        const method = 'checks'
-
-        await this.metricsRecorder.recordMetric({
-          requestID,
-          applicationID: application.id,
-          applicationPublicKey: application.gatewayAAT.applicationPublicKey,
-          blockchainID,
-          serviceNode: 'session-failure',
-          relayStart,
-          result: 500,
-          bytes: Buffer.byteLength(error, 'utf8'),
-          delivered: false,
-          fallback: false,
-          method,
-          error,
-          origin: this.origin,
-          data,
-          sessionKey,
-        })
-
-        return new Error('Sync check failure; using fallbacks')
       }
 
       // EVM-chains always have chain/sync checks.

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -540,6 +540,7 @@ export class PocketRelayer {
           data,
           sessionKey,
         })
+
         return new Error('ChainID check failure; using fallbacks')
       }
 

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -574,7 +574,7 @@ export class PocketRelayer {
       }
 
       // EVM-chains always have chain/sync checks.
-      if (chainCheckedNodes.length > 0 && syncCheckedNodes.length > 0) {
+      if (blockchainIDCheck && blockchainSyncCheck) {
         const filteredNodes = this.filterCheckedNodes(syncCheckedNodes, chainCheckedNodes)
 
         // There's a chance that no nodes passes both checks.
@@ -583,7 +583,7 @@ export class PocketRelayer {
         } else {
           return new Error('Sync / chain check failure; using fallbacks')
         }
-      } else if (syncCheckedNodes.length > 0) {
+      } else if (blockchainSyncCheck) {
         // For non-EVM chains that only have sync check, like pocket.
         nodes = syncCheckedNodes
       }


### PR DESCRIPTION
This logic was modified to solve a known bug, during a small refactor we missed a logic error while reviewing the code. This bug would cause all chains without chain check to go to altruists. 