### PR TITLE
hotfixes for influx; making the write API shared

### DIFF
--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -12,6 +12,8 @@ import { PocketRelayer, SendRelayOptions } from '../services/pocket-relayer'
 import { SyncChecker } from '../services/sync-checker'
 import { ChainChecker } from '../services/chain-checker'
 
+import { WriteApi } from '@influxdata/influxdb-client'
+
 const logger = require('../services/logger')
 
 export class V1Controller {
@@ -42,6 +44,7 @@ export class V1Controller {
     @inject('aatPlan') private aatPlan: string,
     @inject('redirects') private redirects: string,
     @inject('defaultLogLimitBlocks') private defaultLogLimitBlocks: number,
+    @inject('influxWriteAPI') private influxWriteAPI: WriteApi,
     @repository(ApplicationsRepository)
     public applicationsRepository: ApplicationsRepository,
     @repository(BlockchainsRepository)
@@ -55,6 +58,7 @@ export class V1Controller {
     })
     this.metricsRecorder = new MetricsRecorder({
       redis: this.redis,
+      influxWriteAPI: this.influxWriteAPI,
       pgPool: this.pgPool,
       cherryPicker: this.cherryPicker,
       processUID: this.processUID,

--- a/src/observers/environment.observer.ts
+++ b/src/observers/environment.observer.ts
@@ -33,6 +33,9 @@ export class EnvironmentObserver implements LifeCycleObserver {
     'AAT_PLAN',
     'WATCH',
     'REDIRECTS',
+    'INFLUX_URL',
+    'INFLUX_TOKEN',
+    'INFLUX_ORG',
   ]
 
   private static optionalEnvVars: string[] = ['COMMIT_HASH']


### PR DESCRIPTION
Don't hate me because I branched off of staging.

Develop was too modified and this fix needs to go out.

- stop instantiating a new InfluxDB WriteAPI for each request
- moves InfluxDB WriteAPI creation to the application layer so it is shared across requests
- stops flushing and closing the WriteAPI after every request

This should greatly reduce the write load on Influx.