### PR TITLE
fix: handle specific -32000 user errors

### DIFF
--- a/src/utils/enforcements.ts
+++ b/src/utils/enforcements.ts
@@ -1,6 +1,6 @@
 import { Decryptor } from 'strong-cryptor'
 import { Applications } from '../models'
-import { isEVMError } from './errors'
+import { isUserErrorEVM } from './errors'
 
 export function checkEnforcementJSON(test: string): boolean {
   if (!test || test.length === 0) {
@@ -71,5 +71,5 @@ export function isRelayError(payload: string): boolean {
 
 export function isUserError(payload: string, blockchain?: string): boolean {
   // TODO: Non-evm errors
-  return isEVMError(payload)
+  return isUserErrorEVM(payload)
 }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,5 +1,6 @@
 import { parseJSONRPCError } from './parsing'
 
+// some clients use -32000 for both server/user errors, so message match is needed
 const EVM_USER_ERROR_MSGS = ['execution reverted', 'stack underflow', 'cannot be found']
 
 // EVM clients rely on JsonRpc standard, so we check for those errors.

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,7 +1,7 @@
 import { parseJSONRPCError } from './parsing'
 
 // some clients use -32000 for both server/user errors, so message match is needed
-const EVM_USER_ERROR_MSGS = ['execution reverted', 'stack underflow', 'cannot be found']
+const EVM_USER_ERROR_MSGS = ['execution reverted', 'stack underflow', 'cannot be found', 'missing trie node']
 
 // EVM clients rely on JsonRpc standard, so we check for those errors.
 export function isUserErrorEVM(response: string): boolean {
@@ -11,7 +11,7 @@ export function isUserErrorEVM(response: string): boolean {
     const userError = EVM_USER_ERROR_MSGS.some((err) => message.includes(err))
 
     // 3 is execution error
-    // -32000 itself can be thrown for what are server errors (except for execution reverted & stack underflow)
+    // -32000 itself can be thrown for what are server errors
     // all other -32000 are user errors
     return userError || code === 3 || code < -32000
   } catch {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,13 +1,18 @@
 import { parseJSONRPCError } from './parsing'
 
+const EVM_USER_ERROR_MSGS = ['execution reverted', 'stack underflow', 'cannot be found']
+
 // EVM clients rely on JsonRpc standard, so we check for those errors.
-export function isEVMError(response: string): boolean {
+export function isUserErrorEVM(response: string): boolean {
   try {
-    const { code } = parseJSONRPCError(response)
+    const { code, message } = parseJSONRPCError(response)
+
+    const userError = EVM_USER_ERROR_MSGS.some((err) => message.includes(err))
 
     // 3 is execution error
-    // -32000 itself can be thrown for what are server errors, all other -32000 are user errors
-    return code === 3 || code < -32000
+    // -32000 itself can be thrown for what are server errors (except for execution reverted & stack underflow)
+    // all other -32000 are user errors
+    return userError || code === 3 || code < -32000
   } catch {
     return false
   }

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -1824,6 +1824,134 @@ describe('Pocket relayer service (unit)', () => {
 
         expect(relayResponse.error.message).to.match(/method cannot be served over HTTPS/)
       })
+
+      describe('Relays with EVM errors', () => {
+        it('should succeed with a fallback when relay response returns a valid EVM server error (not user)', async () => {
+          logSpy = sinon.spy(logger, 'log')
+
+          const mock = new PocketMock()
+
+          const { chainChecker: mockChainChecker, syncChecker: mockSyncChecker } = mockChainAndSyncChecker(5, 5)
+
+          mock.relayResponse[rawData] =
+            '{"error":{"code":-32000,"message":"missing trie node a42a0d32d5fe7161720b3bd78559744e542918a04fb36714176f67226066a167 (path )"},"id":2,"jsonrpc":"2.0"}'
+
+          const mockAltruistRelayResponse = '{"id":1,"jsonrpc":"2.0","result":"0x64"}'
+
+          axiosMock.onPost(BLOCKCHAINS['0040']?.altruist, JSON.parse(rawData)).reply(200, mockAltruistRelayResponse)
+
+          const relayer = mock.object()
+
+          const poktRelayer = new PocketRelayer({
+            host: 'eth-mainnet',
+            origin: '',
+            userAgent: '',
+            ipAddress: '',
+            relayer,
+            cherryPicker,
+            metricsRecorder,
+            syncChecker: mockSyncChecker,
+            chainChecker: mockChainChecker,
+            cache,
+            databaseEncryptionKey: DB_ENCRYPTION_KEY,
+            secretKey: '',
+            relayRetries: 0,
+            blockchainsRepository: blockchainRepository,
+            checkDebug: true,
+            aatPlan: AatPlans.FREEMIUM,
+            defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+            dispatchers: DUMMY_ENV.DISPATCH_URL,
+          })
+
+          const relayResponse = await poktRelayer.sendRelay({
+            rawData,
+            relayPath: '',
+            httpMethod: HTTPMethod.POST,
+            application: APPLICATION as unknown as Applications,
+            requestID: '1234',
+            requestTimeOut: undefined,
+            overallTimeOut: undefined,
+            stickinessOptions: {
+              stickiness: false,
+              duration: 0,
+              preferredNodeAddress: '',
+            },
+            relayRetries: 0,
+          })
+
+          const expectedAltruistSuccessLog = logSpy.calledWith(
+            'info',
+            sinon.match((arg: string) => arg.includes('SUCCESS FALLBACK RELAYING'))
+          )
+
+          expect(expectedAltruistSuccessLog).to.be.true()
+
+          const expected = JSON.parse(mockAltruistRelayResponse)
+
+          expect(relayResponse).to.be.deepEqual(expected)
+        })
+
+        it('should succeed when relay response returns a valid EVM user error', async () => {
+          logSpy = sinon.spy(logger, 'log')
+
+          const mock = new PocketMock()
+
+          const { chainChecker: mockChainChecker, syncChecker: mockSyncChecker } = mockChainAndSyncChecker(5, 5)
+
+          mock.relayResponse[rawData] =
+            '{"error":{"code":-32000,"message":"execution reverted"},"id":1,"jsonrpc":"2.0"}'
+
+          const relayer = mock.object()
+
+          const poktRelayer = new PocketRelayer({
+            host: 'eth-mainnet',
+            origin: '',
+            userAgent: '',
+            ipAddress: '',
+            relayer,
+            cherryPicker,
+            metricsRecorder,
+            syncChecker: mockSyncChecker,
+            chainChecker: mockChainChecker,
+            cache,
+            databaseEncryptionKey: DB_ENCRYPTION_KEY,
+            secretKey: '',
+            relayRetries: 0,
+            blockchainsRepository: blockchainRepository,
+            checkDebug: true,
+            aatPlan: AatPlans.FREEMIUM,
+            defaultLogLimitBlocks: DEFAULT_LOG_LIMIT,
+            dispatchers: DUMMY_ENV.DISPATCH_URL,
+          })
+
+          const relayResponse = await poktRelayer.sendRelay({
+            rawData,
+            relayPath: '',
+            httpMethod: HTTPMethod.POST,
+            application: APPLICATION as unknown as Applications,
+            requestID: '1234',
+            requestTimeOut: undefined,
+            overallTimeOut: undefined,
+            stickinessOptions: {
+              stickiness: false,
+              duration: 0,
+              preferredNodeAddress: '',
+            },
+            relayRetries: 0,
+          })
+
+          const expectedSuccessLog = logSpy.calledWith(
+            'info',
+            sinon.match((arg: string) => arg.includes('SUCCESS RELAYING'))
+          )
+
+          expect(expectedSuccessLog).to.be.true()
+
+          const expected = JSON.parse(mock.relayResponse[rawData] as string)
+
+          expect(relayResponse).to.be.deepEqual(expected)
+        })
+      })
     })
   })
 })

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -1834,7 +1834,7 @@ describe('Pocket relayer service (unit)', () => {
           const { chainChecker: mockChainChecker, syncChecker: mockSyncChecker } = mockChainAndSyncChecker(5, 5)
 
           mock.relayResponse[rawData] =
-            '{"error":{"code":-32000,"message":"missing trie node a42a0d32d5fe7161720b3bd78559744e542918a04fb36714176f67226066a167 (path )"},"id":2,"jsonrpc":"2.0"}'
+            '{"error":{"code":-32000,"message":"rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 127.0.0.1:9090: connect: connection refused""},"id":732830328053361800,"jsonrpc":"2.0"}'
 
           const mockAltruistRelayResponse = '{"id":1,"jsonrpc":"2.0","result":"0x64"}'
 


### PR DESCRIPTION
As per #848, only errors below -32000 were deemed as user errors (spec says so). In reality, there are user errors that are marked as -32000 (same as server errors). 

This PR includes some message assertion on -32000s to separate server errors from user errors.