### PR TITLE
fix: cherry picker weighted latency formula

### DIFF
--- a/tests/unit/cherry-picker.unit.ts
+++ b/tests/unit/cherry-picker.unit.ts
@@ -275,7 +275,7 @@ describe('Cherry picker service (unit)', () => {
       const session = await new PocketMock().object().getNewSession(undefined)
       const expectedLogs = JSON.stringify({
         medianSuccessLatency: '0.25000',
-        weightedSuccessLatency: '0.32860', // average after calculation from fn
+        weightedSuccessLatency: '0.25360', // average after calculation from fn
         results: {
           '200': 25,
           '500': 2,


### PR DESCRIPTION
This PR brings in fixes suggested by discord user `msa6867#1823`.

Given the user's comment about not being comfortable with Git, @blockjoe wanted to just pull in the changes since they were quick/simple so that the user could say if this is what they were suggesting.

Issue: 
Nodes past 20 relays mark (majority of them) are being calculated at 100% median latency + 30% P90 latency.

```
Actual Formula (100% median + 30% p90)
Name	Median	P90	Weighted Latency
Node1 - 100	135	100 + 40.5 = 140.5
Node2 - 112	119	112 + 35.7 = 147.7
Node3 - 115	117	115 + 35.1 = 150.1
Node4 - 125	126	125 + 37.8 = 162.8
Node5 - 120	123	120 + 36.9 = 156.9

Proposed Formula (70% median + 30% p90)
Name	Median	P90	Weighted Latency
Node1 - 100	135	70 + 40.5 = 110.5
Node2 - 112	119	78.4 + 35.7 = 114.1
Node3 - 115	117	80.5 + 35.1 = 115.6
Node4 - 125	126	87.5 + 37.8 = 125.3
Node5 - 120	123	84 + 36.9 = 120.9
```
Note: this is artificial data, not from an actual session.

As you see, using the actual formula you take nodes out of the top bucket with both median/p90 within requirements (<150ms). After the adjustment, this will no longer happen.