### PR TITLE
feat: add region to relay headers

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -69,6 +69,7 @@ export class PocketGatewayApplication extends BootMixin(ServiceMixin(RepositoryM
       REDIS_LOCAL_TTL_FACTOR,
       RATE_LIMITER_URL,
       RATE_LIMITER_TOKEN,
+      REGION,
     }: // eslint-disable-next-line @typescript-eslint/no-explicit-any
     any = await this.get('configuration.environment.values')
 
@@ -89,6 +90,7 @@ export class PocketGatewayApplication extends BootMixin(ServiceMixin(RepositoryM
     const ttlFactor = parseFloat(REDIS_LOCAL_TTL_FACTOR) || 1
     const rateLimiterURL: string = RATE_LIMITER_URL || ''
     const rateLimiterToken: string = RATE_LIMITER_TOKEN || ''
+    const region: string = REGION || ''
 
     if (aatPlan !== AatPlans.PREMIUM && !AatPlans.values.includes(aatPlan)) {
       throw new HttpErrors.InternalServerError('Unrecognized AAT Plan')
@@ -112,6 +114,7 @@ export class PocketGatewayApplication extends BootMixin(ServiceMixin(RepositoryM
     this.bind('alwaysRedirectToAltruists').to(alwaysRedirectToAltruists)
     this.bind('rateLimiterURL').to(rateLimiterURL)
     this.bind('rateLimiterToken').to(rateLimiterToken)
+    this.bind('region').to(region)
 
     const redisPort: string = REDIS_PORT || ''
 

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -101,6 +101,7 @@ export class V1Controller {
     this.pocketRelayer = new PocketRelayer({
       host: this.host,
       origin: this.origin,
+      headers: { 'Content-Type': 'application/json', region: this.region },
       userAgent: this.userAgent,
       ipAddress: this.ipAddress,
       relayer: this.relayer,
@@ -362,7 +363,6 @@ export class V1Controller {
         rawData,
         relayPath: this.relayPath,
         httpMethod: this.httpMethod,
-        headers: { region: this.region },
         application,
         requestID: this.requestID,
         requestTimeOut: parseInt(loadBalancer.requestTimeOut),
@@ -517,7 +517,6 @@ export class V1Controller {
         application,
         relayPath: this.relayPath,
         httpMethod: this.httpMethod,
-        headers: { region: this.region },
         requestID: this.requestID,
         stickinessOptions: {
           stickiness,

--- a/src/controllers/v1.controller.ts
+++ b/src/controllers/v1.controller.ts
@@ -48,6 +48,7 @@ export class V1Controller {
     @inject('secretKey') private secretKey: string,
     @inject('host') private host: string,
     @inject('origin') private origin: string,
+    @inject('region') private region: string,
     @inject('userAgent') private userAgent: string,
     @inject('contentType') private contentType: string,
     @inject('ipAddress') private ipAddress: string,
@@ -88,9 +89,15 @@ export class V1Controller {
       cherryPicker: this.cherryPicker,
       processUID: this.processUID,
     })
-    this.syncChecker = new SyncChecker(this.cache, this.metricsRecorder, this.defaultSyncAllowance, this.origin)
-    this.chainChecker = new ChainChecker(this.cache, this.metricsRecorder, this.origin)
-    this.mergeChecker = new MergeChecker(this.cache, this.metricsRecorder, this.origin)
+    this.syncChecker = new SyncChecker(
+      this.cache,
+      this.metricsRecorder,
+      this.defaultSyncAllowance,
+      this.origin,
+      this.region
+    )
+    this.chainChecker = new ChainChecker(this.cache, this.metricsRecorder, this.origin, this.region)
+    this.mergeChecker = new MergeChecker(this.cache, this.metricsRecorder, this.origin, this.region)
     this.pocketRelayer = new PocketRelayer({
       host: this.host,
       origin: this.origin,
@@ -355,6 +362,7 @@ export class V1Controller {
         rawData,
         relayPath: this.relayPath,
         httpMethod: this.httpMethod,
+        headers: { region: this.region },
         application,
         requestID: this.requestID,
         requestTimeOut: parseInt(loadBalancer.requestTimeOut),
@@ -509,6 +517,7 @@ export class V1Controller {
         application,
         relayPath: this.relayPath,
         httpMethod: this.httpMethod,
+        headers: { region: this.region },
         requestID: this.requestID,
         stickinessOptions: {
           stickiness,

--- a/src/services/chain-checker.ts
+++ b/src/services/chain-checker.ts
@@ -272,7 +272,7 @@ export class ChainChecker {
         blockchain: blockchainID,
         data: chainCheck,
         method: '',
-        headers: { region: this.region },
+        headers: { 'Content-Type': 'application/json', region: this.region },
         path,
         node,
         pocketAAT,

--- a/src/services/chain-checker.ts
+++ b/src/services/chain-checker.ts
@@ -21,11 +21,13 @@ export class ChainChecker {
   metricsRecorder: MetricsRecorder
   origin: string
   sessionErrors: number
+  region: string
 
-  constructor(cache: Cache, metricsRecorder: MetricsRecorder, origin: string) {
+  constructor(cache: Cache, metricsRecorder: MetricsRecorder, origin: string, region: string) {
     this.cache = cache
     this.metricsRecorder = metricsRecorder
     this.origin = origin
+    this.region = region
   }
 
   async chainIDFilter({
@@ -270,6 +272,7 @@ export class ChainChecker {
         blockchain: blockchainID,
         data: chainCheck,
         method: '',
+        headers: { region: this.region },
         path,
         node,
         pocketAAT,

--- a/src/services/merge-checker.ts
+++ b/src/services/merge-checker.ts
@@ -31,11 +31,13 @@ export class MergeChecker {
   metricsRecorder: MetricsRecorder
   origin: string
   sessionErrors: number
+  region: string
 
-  constructor(cache: Cache, metricsRecorder: MetricsRecorder, origin: string) {
+  constructor(cache: Cache, metricsRecorder: MetricsRecorder, origin: string, region: string) {
     this.cache = cache
     this.metricsRecorder = metricsRecorder
     this.origin = origin
+    this.region = region
   }
 
   async mergeStatusFilter({
@@ -288,6 +290,7 @@ export class MergeChecker {
         blockchain: blockchainID,
         data: MERGE_CHECK_PAYLOAD,
         method: '',
+        headers: { region: this.region },
         path,
         node,
         pocketAAT,

--- a/src/services/merge-checker.ts
+++ b/src/services/merge-checker.ts
@@ -290,7 +290,7 @@ export class MergeChecker {
         blockchain: blockchainID,
         data: MERGE_CHECK_PAYLOAD,
         method: '',
-        headers: { region: this.region },
+        headers: { 'Content-Type': 'application/json', region: this.region },
         path,
         node,
         pocketAAT,

--- a/src/services/pocket-relayer.ts
+++ b/src/services/pocket-relayer.ts
@@ -1,5 +1,5 @@
 import { EvidenceSealedError, Relayer } from '@pokt-foundation/pocketjs-relayer'
-import { Session, Node, PocketAAT, HTTPMethod } from '@pokt-foundation/pocketjs-types'
+import { Session, Node, PocketAAT, HTTPMethod, RelayHeaders } from '@pokt-foundation/pocketjs-types'
 import axios, { AxiosRequestConfig, Method } from 'axios'
 import jsonrpc, { ErrorObject, IParsedObject } from 'jsonrpc-lite'
 import AatPlans from '../config/aat-plans.json'
@@ -34,6 +34,7 @@ const logger = require('../services/logger')
 export class PocketRelayer {
   host: string
   origin: string
+  headers?: RelayHeaders
   userAgent: string
   ipAddress: string
   relayer: Relayer
@@ -57,6 +58,7 @@ export class PocketRelayer {
   constructor({
     host,
     origin,
+    headers = {},
     userAgent,
     ipAddress,
     relayer,
@@ -78,6 +80,7 @@ export class PocketRelayer {
   }: {
     host: string
     origin: string
+    headers?: RelayHeaders
     userAgent: string
     ipAddress: string
     relayer: Relayer
@@ -99,6 +102,7 @@ export class PocketRelayer {
   }) {
     this.host = host
     this.origin = origin
+    this.headers = headers
     this.userAgent = userAgent
     this.ipAddress = ipAddress
     this.relayer = relayer
@@ -881,6 +885,7 @@ export class PocketRelayer {
         blockchain: blockchainID,
         data,
         method: '',
+        headers: this.headers,
         node,
         path: relayPath,
         pocketAAT,

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -24,12 +24,20 @@ export class SyncChecker {
   defaultSyncAllowance: number
   origin: string
   sessionErrors: number
+  region: string
 
-  constructor(cache: Cache, metricsRecorder: MetricsRecorder, defaultSyncAllowance: number, origin: string) {
+  constructor(
+    cache: Cache,
+    metricsRecorder: MetricsRecorder,
+    defaultSyncAllowance: number,
+    origin: string,
+    region: string
+  ) {
     this.cache = cache
     this.metricsRecorder = metricsRecorder
     this.defaultSyncAllowance = defaultSyncAllowance
     this.origin = origin
+    this.region = region
     this.sessionErrors = 0
   }
 
@@ -451,6 +459,7 @@ export class SyncChecker {
         path: syncCheckOptions.path,
         node,
         method: '',
+        headers: { region: this.region },
         pocketAAT,
         session,
         options: {

--- a/src/services/sync-checker.ts
+++ b/src/services/sync-checker.ts
@@ -459,7 +459,7 @@ export class SyncChecker {
         path: syncCheckOptions.path,
         node,
         method: '',
-        headers: { region: this.region },
+        headers: { 'Content-Type': 'application/json', region: this.region },
         pocketAAT,
         session,
         options: {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,4 @@
-import { Node, HTTPMethod, StakingStatus, RelayHeaders } from '@pokt-foundation/pocketjs-types'
+import { Node, HTTPMethod, StakingStatus } from '@pokt-foundation/pocketjs-types'
 import { Applications } from '../models'
 import { SyncCheckOptions } from '../services/sync-checker'
 
@@ -19,7 +19,6 @@ export type SendRelayOptions = {
   application: Applications
   stickinessOptions: StickinessOptions
   httpMethod: HTTPMethod
-  headers?: RelayHeaders
   overallTimeOut?: number
   rawData: object | string
   relayPath: string

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,4 @@
-import { Node, HTTPMethod, StakingStatus } from '@pokt-foundation/pocketjs-types'
+import { Node, HTTPMethod, StakingStatus, RelayHeaders } from '@pokt-foundation/pocketjs-types'
 import { Applications } from '../models'
 import { SyncCheckOptions } from '../services/sync-checker'
 
@@ -19,6 +19,7 @@ export type SendRelayOptions = {
   application: Applications
   stickinessOptions: StickinessOptions
   httpMethod: HTTPMethod
+  headers?: RelayHeaders
   overallTimeOut?: number
   rawData: object | string
   relayPath: string

--- a/tests/unit/chain-checker.unit.ts
+++ b/tests/unit/chain-checker.unit.ts
@@ -28,12 +28,13 @@ describe('Chain checker service (unit)', () => {
   let axiosMock: MockAdapter
 
   const origin = 'unit-test'
+  const region = 'us-east-1'
 
   before('initialize variables', async () => {
     cache = new Cache(new Redis(0, ''), new Redis(1, ''))
     cherryPicker = new CherryPicker({ redis: cache.remote, checkDebug: false })
     metricsRecorder = metricsRecorderMock(cache.remote, cherryPicker)
-    chainChecker = new ChainChecker(cache, metricsRecorder, origin)
+    chainChecker = new ChainChecker(cache, metricsRecorder, origin, region)
 
     axiosMock = new MockAdapter(axios)
     axiosMock.onPost('https://user:pass@backups.example.org:18081/v1/query/node').reply(200, {

--- a/tests/unit/merge-checker.unit.ts
+++ b/tests/unit/merge-checker.unit.ts
@@ -34,12 +34,13 @@ describe('Merge checker service (unit)', () => {
   let axiosMock: MockAdapter
 
   const origin = 'unit-test'
+  const region = 'us-east-1'
 
   before('initialize variables', async () => {
     cache = new Cache(new Redis(0, ''), new Redis(1, ''))
     cherryPicker = new CherryPicker({ redis: cache.remote, checkDebug: false })
     metricsRecorder = metricsRecorderMock(cache.remote, cherryPicker)
-    mergeChecker = new MergeChecker(cache, metricsRecorder, origin)
+    mergeChecker = new MergeChecker(cache, metricsRecorder, origin, region)
 
     axiosMock = new MockAdapter(axios)
     axiosMock.onPost('https://user:pass@backups.example.org:18081/v1/query/node').reply(200, {

--- a/tests/unit/pocket-relayer.unit.ts
+++ b/tests/unit/pocket-relayer.unit.ts
@@ -150,14 +150,15 @@ describe('Pocket relayer service (unit)', () => {
   let logSpy: sinon.SinonSpy
 
   const origin = 'unit-test'
+  const region = 'us-east-1'
 
   before('initialize variables', async () => {
     cache = new Cache(new Redis(0, ''), new Redis(1, ''))
     cherryPicker = new CherryPicker({ redis: cache.remote, checkDebug: false })
     metricsRecorder = metricsRecorderMock(cache.remote, cherryPicker)
-    chainChecker = new ChainChecker(cache, metricsRecorder, origin)
-    syncChecker = new SyncChecker(cache, metricsRecorder, 5, origin)
-    mergeChecker = new MergeChecker(cache, metricsRecorder, origin)
+    chainChecker = new ChainChecker(cache, metricsRecorder, origin, region)
+    syncChecker = new SyncChecker(cache, metricsRecorder, 5, origin, region)
+    mergeChecker = new MergeChecker(cache, metricsRecorder, origin, region)
     blockchainRepository = new BlockchainsRepository(gatewayTestDB)
 
     pocketMock = new PocketMock()

--- a/tests/unit/sync-checker.unit.ts
+++ b/tests/unit/sync-checker.unit.ts
@@ -111,12 +111,13 @@ describe('Sync checker service (unit)', () => {
   let logSpy: sinon.SinonSpy
 
   const origin = 'unit-test'
+  const region = 'us-east-1'
 
   before('initialize variables', async () => {
     cache = new Cache(new Redis(0, ''), new Redis(1, ''))
     cherryPicker = new CherryPicker({ redis: cache.remote, checkDebug: false })
     metricsRecorder = metricsRecorderMock(cache.remote, cherryPicker)
-    syncChecker = new SyncChecker(cache, metricsRecorder, DEFAULT_SYNC_ALLOWANCE, origin)
+    syncChecker = new SyncChecker(cache, metricsRecorder, DEFAULT_SYNC_ALLOWANCE, origin, region)
     pocketMock = new PocketMock()
     axiosMock = new MockAdapter(axios)
   })


### PR DESCRIPTION
This PR adds a header containing the region to relays (including check relays) - this will greatly help the community to play around with their Geo-locations and see clearly where the traffic is coming from.